### PR TITLE
Consistent font sizing for <a> nested in .description

### DIFF
--- a/assets/css/gaia.css
+++ b/assets/css/gaia.css
@@ -255,6 +255,10 @@ p.description {
   color: #777777;
 }
 
+p.description a {
+  font-size: 16px;
+}
+
 a:hover, a:focus {
   text-decoration: none;
 }


### PR DESCRIPTION
Fixes weirdness where links in a sentence are a different font size :) 